### PR TITLE
Added return statements to allow error-free build

### DIFF
--- a/src/main/java/is/ru/tictactoe/Board.java
+++ b/src/main/java/is/ru/tictactoe/Board.java
@@ -9,14 +9,14 @@ public class Board {
 	}
 
 	public Player checkWinner() {
-
+		return null;
 	}
 
 	public Boolean insert(Move move) {
-
+		return false;
 	}
 
 	public Boolean isFull() {
-
+		return false;
 	}
 }


### PR DESCRIPTION
Forgot to add in return statements, so when building we got a compile error. Fixed this by adding default falsey return statements.
